### PR TITLE
Fix IsADirectoryError when including files recursively by ** pattern

### DIFF
--- a/appimagebuilder/modules/deploy/files/deploy_helper.py
+++ b/appimagebuilder/modules/deploy/files/deploy_helper.py
@@ -111,7 +111,8 @@ class FileDeploy:
             expanded_list = expanded_list.union(glob.glob(path, recursive=True))
 
         for path in expanded_list:
-            self._deploy_path(path)
+            if os.path.isfile(path):
+                self._deploy_path(path)
 
     def _deploy_path(self, path):
         deploy_prefix = self._resolve_deploy_prefix(path)


### PR DESCRIPTION
Including files recursively by ** glob pattern raises IsADirectoryError because glob returns all paths including directories (https://docs.python.org/3/library/glob.html#glob.glob) while shutil.copy2 expects files only. Assuming the paths should be filtered for files before handing over to shutil. Not sure what is expected about empty directories ...